### PR TITLE
Fix innodb-buffer-size error

### DIFF
--- a/juju/checks/openstack.yaml
+++ b/juju/checks/openstack.yaml
@@ -11,6 +11,7 @@ checks:
           scope: config
           source: local
           value: 6G
+          warn-on-fail: true
           description: |
             DB must be allowed to cache as useful amount of data corresponding
             to the amount of memory available to the unit.
@@ -33,6 +34,7 @@ checks:
           scope: config
           source: local
           value: 6G
+          warn-on-fail: true
           description: |
             DB must be allowed to cache as useful amount of data corresponding
             to the amount of memory available to the unit.


### PR DESCRIPTION
Especially with Kubernetes, we are using mysql-innodb-cluster
only for Vault storage backend. The default value is actually
sufficient. So, changing it from FAIL -> WARN.

Closes #8