### PR TITLE
Allow sysconfig charm to be installed from latest/stable channel

### DIFF
--- a/juju/checks/openstack.yaml
+++ b/juju/checks/openstack.yaml
@@ -252,6 +252,13 @@ checks:
   sysconfig:
     charm: sysconfig
     assertions:
+      channel:
+        # etcd charm is shipped in the latest/stable channel and has no
+        # stable channels so we override the default check to allow
+        # latest/stable.
+        assert_channel:
+          scope: application
+          value: latest/stable
       governor:
         eq:
           scope: config


### PR DESCRIPTION
Adds support for overriding the default charm application scope channel so that charms that only use latest/stable dont raise an error.