### PR TITLE
[ceph] allow default for osd-memory-target

### DIFF
--- a/juju/checks/ceph.yaml
+++ b/juju/checks/ceph.yaml
@@ -24,7 +24,9 @@ checks:
         gte:
           value: 1G
       tune-osd-memory-target:
-        isset:
+        allow_default:
+        gte:
+          value: 4G
   ceph-proxy:
     charm: ceph-proxy
     assertions:


### PR DESCRIPTION
If osd_memory_target isn't set, it's not an issue. But if it's set, we can check if it's at least 4G (default).

Fixes #67.