### PR TITLE
Fix virt-type check

### DIFF
--- a/juju/checks/openstack.yaml
+++ b/juju/checks/openstack.yaml
@@ -221,9 +221,7 @@ charmed-openstack:
               performing live-migrations.
         virt-type:
           allow_default:
-            source: bundle
           eq:
-            source: bundle
             value: "kvm"
             description: >-
               For production environments 'virt-type' must be set to 'kvm' or


### PR DESCRIPTION
Without this patch the 'virt-type' check fails even if the value is set to 'kvm'